### PR TITLE
Fix building with non-default backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 debug_stub_derive = "0.3.0"
-cursive = "0.7"
+
+[dependencies.cursive]
+version = "0.7"
+default-features = false
 
 [features]
 default = ["ncurses-backend"]


### PR DESCRIPTION
Specifying a non-default (i.e. non-ncurses) backend currently fails
since the default features of cursive are still pulled in. Disable
default-features for cursive to fix this.